### PR TITLE
Hiding the PING window under Windows OS

### DIFF
--- a/advanced-ping/advanced-ping.js
+++ b/advanced-ping/advanced-ping.js
@@ -42,7 +42,7 @@ module.exports = function(RED) {
 
 			var ex;
 			if (plat == "linux") { ex = spawn('ping', ['-n', '-w', node.timeout, '-c', node.requests, host]); }
-			else if (plat.match(/^win/)) { ex = spawn('ping', ['-n', node.requests, '-w', node.timeout*1000, host]); }
+			else if (plat.match(/^win/)) { ex = spawn('ping', ['-n', node.requests, '-w', node.timeout*1000, host],{windowsHide: true}); }
 			else if (plat == "darwin") { ex = spawn('ping', ['-n', '-t', node.timeout, '-c', node.requests, host]); }
 			else { node.error("Sorry - your platform - "+plat+" - is not recognised."); }
 			var res = false;


### PR DESCRIPTION
Prior to this change, the PING window would pop up on the computer, this make the command run hidden in the background